### PR TITLE
Take user input to close animations ( Closes #12 )

### DIFF
--- a/vgit/animations/base.py
+++ b/vgit/animations/base.py
@@ -11,6 +11,10 @@ class AnimationController:
         self._stop_event.set()
         self._thread.join()
 
+    def is_stopped(self):
+        """Return True if the animation has been requested to stop."""
+        return self._stop_event.is_set()
+
 def start_animation(window, render_fn, git_state):
     stop_event = threading.Event()
 

--- a/vgit/animations/base.py
+++ b/vgit/animations/base.py
@@ -19,24 +19,10 @@ def start_animation(window, render_fn, git_state):
     stop_event = threading.Event()
 
     def run():
-        # Make key reads non-blocking so we can detect SPACE to exit
-        try:
-            window.nodelay(True)
-        except Exception:
-            pass
         while not stop_event.is_set():
             window.clear()
             render_fn(window, git_state)
             window.refresh()
-            # Check for SPACE (or 'q') to stop
-            try:
-                ch = window.getch()
-                if ch in (32, ord('q')):  # SPACE or 'q'
-                    stop_event.set()
-                    break
-            except Exception:
-                # Ignore getch errors (e.g., window too small)
-                pass
             time.sleep(0.5)
 
     thread = threading.Thread(target=run, daemon=True)

--- a/vgit/animations/base.py
+++ b/vgit/animations/base.py
@@ -19,10 +19,24 @@ def start_animation(window, render_fn, git_state):
     stop_event = threading.Event()
 
     def run():
+        # Make key reads non-blocking so we can detect SPACE to exit
+        try:
+            window.nodelay(True)
+        except Exception:
+            pass
         while not stop_event.is_set():
             window.clear()
             render_fn(window, git_state)
             window.refresh()
+            # Check for SPACE (or 'q') to stop
+            try:
+                ch = window.getch()
+                if ch in (32, ord('q')):  # SPACE or 'q'
+                    stop_event.set()
+                    break
+            except Exception:
+                # Ignore getch errors (e.g., window too small)
+                pass
             time.sleep(0.5)
 
     thread = threading.Thread(target=run, daemon=True)

--- a/vgit/animations/fetch.py
+++ b/vgit/animations/fetch.py
@@ -53,7 +53,7 @@ def render(window, state):
         pass
 
     left_x = cfg.STATUS_X_POSITIONS.get("untracked", 5)
-    right_x = cfg.STATUS_X_POSITIONS.get("committed", 65)
+    right_x = cfg.STATUS_X_POSITIONS.get("staged", 65)
     line_y = cfg.ROW_Y + 2
 
     # Draw static parts
@@ -77,8 +77,8 @@ def render(window, state):
     except Exception:
         pass
 
-    window.addstr(line_y + 5, left_x - 2, "Local Ref:", curses.color_pair(cfg.STATUS_COLORS["yellow"]))
-    draw_box(window, line_y + 2, left_x + 8, 5, 9, cfg.STATUS_COLORS["yellow"], [(3, 4, "•")])
+    window.addstr(line_y + 1, left_x - 2, "Local Ref:", curses.color_pair(cfg.STATUS_COLORS["yellow"]))
+    draw_box(window, line_y + 1, left_x + 8, 5, 9, cfg.STATUS_COLORS["yellow"], [(3, 4, "•")])
 
        # ===================== ANIMATION =====================
     if state._fetch_stage == "fetching":

--- a/vgit/animations/status.py
+++ b/vgit/animations/status.py
@@ -8,7 +8,7 @@ def draw_box(win, y, x, color, title, symbols):
     Draws an individual box with title and content.
     """
     win.attron(curses.color_pair(color))
-    height, width = 6, 14
+    height, width = cfg.BOX_HEIGHT,cfg.BOX_WIDTH
 
     # Title centered
     win.addstr(y, x + (width - len(title)) // 2, title)
@@ -62,10 +62,10 @@ def render(window, state):
     draw_box(
         window, cfg.ROW_Y, cfg.STATUS_X_POSITIONS["committed"],
         cfg.STATUS_COLORS["yellow"], "Committed",
-        [(3, 3, f"↑{state.ahead}"), (3, 9, f"↓{state.behind}")]
+        [(3, 3, f"↑{state.ahead}"), (3, 6, f"↓{state.behind}")]
     )
 
-    window.addstr(cfg.BOTTOM_ROW_TEXT_Y, cfg.STATUS_X_POSITIONS["committed"] + 1, "-1 = No remote", curses.color_pair(cfg.STATUS_COLORS["yellow"]))
+    window.addstr(cfg.BOTTOM_ROW_TEXT_Y, cfg.STATUS_X_POSITIONS["committed"] , "-1 = No remote", curses.color_pair(cfg.STATUS_COLORS["yellow"]))
 
 def start(window, git_state):
     return start_animation(window, render, git_state)

--- a/vgit/animations/status.py
+++ b/vgit/animations/status.py
@@ -44,28 +44,28 @@ def render(window, state):
     draw_box(
         window, cfg.ROW_Y, cfg.STATUS_X_POSITIONS["untracked"],
         cfg.STATUS_COLORS["magenta"], "Untracked",
-        [(3, 4, "•"), (3, 6, str(state.untracked))]
+        [(cfg.SymbolPosX, cfg.SymbolPosY, "•"), (cfg.SymbolPosX, 5, str(state.untracked))]
     )
 
     draw_box(
         window, cfg.ROW_Y, cfg.STATUS_X_POSITIONS["changed"],
         cfg.STATUS_COLORS["red"], "Changed",
-        [(3, 4, "+"), (3, 6, str(state.changed))]
+        [(cfg.SymbolPosX,cfg.SymbolPosY, "+"), (cfg.SymbolPosX, 5, str(state.changed))]
     )
 
     draw_box(
         window, cfg.ROW_Y, cfg.STATUS_X_POSITIONS["staged"],
         cfg.STATUS_COLORS["green"], "Staged",
-        [(3, 4, "#"), (3, 6, str(state.staged))]
+        [(cfg.SymbolPosX, cfg.SymbolPosY, "#"), (cfg.SymbolPosX, 5, str(state.staged))]
     )
 
     draw_box(
         window, cfg.ROW_Y, cfg.STATUS_X_POSITIONS["committed"],
         cfg.STATUS_COLORS["yellow"], "Committed",
-        [(3, 3, f"↑{state.ahead}"), (3, 6, f"↓{state.behind}")]
+        [(cfg.SymbolPosX, cfg.SymbolPosY, f"↑{state.ahead}"), (cfg.SymbolPosX, 5, f"↓{state.behind}")]
     )
 
-    window.addstr(cfg.BOTTOM_ROW_TEXT_Y, cfg.STATUS_X_POSITIONS["committed"] , "-1 = No remote", curses.color_pair(cfg.STATUS_COLORS["yellow"]))
+    window.addstr(cfg.BOTTOM_ROW_TEXT_Y-2, cfg.STATUS_X_POSITIONS["committed"]-3 , "-1 = No remote", curses.color_pair(cfg.STATUS_COLORS["yellow"]))
 
 def start(window, git_state):
     return start_animation(window, render, git_state)

--- a/vgit/commands/commit.py
+++ b/vgit/commands/commit.py
@@ -62,8 +62,8 @@ def run(top_window, runner):
 
     # Wait until user presses SPACE/'q' to stop animation
     try:
-        window.nodelay(True)
-        window.keypad(True)
+        top_window.nodelay(True)
+        top_window.keypad(True)
     except Exception:
         pass
     while True:

--- a/vgit/commands/commit.py
+++ b/vgit/commands/commit.py
@@ -62,8 +62,8 @@ def run(top_window, runner):
 
     # Wait until user presses SPACE/'q' to stop animation
     try:
-        top_window.nodelay(True)
-        top_window.keypad(True)
+        window.nodelay(True)
+        window.keypad(True)
     except Exception:
         pass
     while True:

--- a/vgit/commands/commit.py
+++ b/vgit/commands/commit.py
@@ -62,15 +62,15 @@ def run(top_window, runner):
 
     # Wait until user presses SPACE/'q' to stop animation
     try:
-        window.nodelay(True)
-        window.keypad(True)
+        top_window.nodelay(True)
+        top_window.keypad(True)
     except Exception:
         pass
     while True:
         if controller.is_stopped():
             break
         try:
-            ch = window.getch()
+            ch = top_window.getch()
             if ch in (32, ord('q')):
                 controller.stop()
                 break

--- a/vgit/commands/commit.py
+++ b/vgit/commands/commit.py
@@ -60,5 +60,21 @@ def run(top_window, runner):
     git_state.commit_hashes = [c.hexsha for c in reversed(last_commits)]
     git_state.commit_messages = [c.message.splitlines()[0] for c in reversed(last_commits)]
 
-    time.sleep(5)
+    # Wait until user presses SPACE/'q' to stop animation
+    try:
+        window.nodelay(True)
+        window.keypad(True)
+    except Exception:
+        pass
+    while True:
+        if controller.is_stopped():
+            break
+        try:
+            ch = window.getch()
+            if ch in (32, ord('q')):
+                controller.stop()
+                break
+        except Exception:
+            pass
+        time.sleep(0.05)
     controller.stop()

--- a/vgit/commands/fetch.py
+++ b/vgit/commands/fetch.py
@@ -15,7 +15,23 @@ def run(top_window, runner):
     controller = fetch_anim.start(top_window, git_state)
 
     runner.run_and_stream()
-    time.sleep(5)
+    # Wait until user presses SPACE/'q' to stop animation
+    try:
+        top_window.nodelay(True)
+        top_window.keypad(True)
+    except Exception:
+        pass
+    while True:
+        if controller.is_stopped():
+            break
+        try:
+            ch = top_window.getch()
+            if ch in (32, ord('q')):
+                controller.stop()
+                break
+        except Exception:
+            pass
+        time.sleep(0.05)
 
     controller.stop()
     print("\n".join(runner.get_output()))

--- a/vgit/commands/fetch.py
+++ b/vgit/commands/fetch.py
@@ -16,22 +16,8 @@ def run(top_window, runner):
 
     runner.run_and_stream()
     # Wait until user presses SPACE/'q' to stop animation
-    try:
-        top_window.nodelay(True)
-        top_window.keypad(True)
-    except Exception:
-        pass
-    while True:
-        if controller.is_stopped():
-            break
-        try:
-            ch = top_window.getch()
-            if ch in (32, ord('q')):
-                controller.stop()
-                break
-        except Exception:
-            pass
-        time.sleep(0.05)
+    while not controller.is_stopped():
+        time.sleep(0.1)
 
     controller.stop()
     print("\n".join(runner.get_output()))

--- a/vgit/commands/fetch.py
+++ b/vgit/commands/fetch.py
@@ -16,8 +16,22 @@ def run(top_window, runner):
 
     runner.run_and_stream()
     # Wait until user presses SPACE/'q' to stop animation
-    while not controller.is_stopped():
-        time.sleep(0.1)
+    try:
+        top_window.nodelay(True)
+        top_window.keypad(True)
+    except Exception:
+        pass
+    while True:
+        if controller.is_stopped():
+            break
+        try:
+            ch = top_window.getch()
+            if ch in (32, ord('q')):
+                controller.stop()
+                break
+        except Exception:
+            pass
+        time.sleep(0.05)
 
     controller.stop()
     print("\n".join(runner.get_output()))

--- a/vgit/commands/status.py
+++ b/vgit/commands/status.py
@@ -14,8 +14,22 @@ def run(top_window, runner):
 
     controller = status_anim.start(top_window, git_state)
     runner.run_and_stream()
-    time.sleep(5)
-
-    controller.stop()
+    # Wait until user presses SPACE/'q' to stop animation
+    try:
+        top_window.nodelay(True)
+        top_window.keypad(True)
+    except Exception:
+        pass
+    while True:
+        if controller.is_stopped():
+            break
+        try:
+            ch = top_window.getch()
+            if ch in (32, ord('q')):
+                controller.stop()
+                break
+        except Exception:
+            pass
+        time.sleep(0.05)
 
     print("\n".join(runner.get_output()))

--- a/vgit/core/ui_config.py
+++ b/vgit/core/ui_config.py
@@ -25,10 +25,12 @@ def update_current_terminal_size(stdscr):
 BOX_HEIGHT = CURRENT_TERMINAL_HEIGHT//7
 BOX_WIDTH = CURRENT_TERMINAL_WIDTH//10
 ROW_Y = 3
-BOTTOM_ROW_TEXT_Y =10
 
 # X positions for git status boxes
 if CURRENT_TERMINAL_WIDTH>78:
+    SymbolPosX=2
+    BOTTOM_ROW_TEXT_Y =10
+    SymbolPosY=2
     STATUS_X_POSITIONS = {
     "untracked": (BOX_WIDTH),
     "changed": BOX_WIDTH+20 ,
@@ -36,6 +38,9 @@ if CURRENT_TERMINAL_WIDTH>78:
     "committed": BOX_WIDTH+60,
 }
 else:
+    SymbolPosX=3
+    BOTTOM_ROW_TEXT_Y =40
+    SymbolPosY=3
     STATUS_X_POSITIONS = {
     "untracked": (BOX_WIDTH),
     "changed": BOX_WIDTH+10 ,

--- a/vgit/core/ui_config.py
+++ b/vgit/core/ui_config.py
@@ -1,21 +1,46 @@
 # core/ui_config.py
 
+import shutil
+
 # Terminal Width and Height
 MIN_TERMINAL_HEIGHT = 30
 MIN_TERMINAL_WIDTH = 110
 
+# Current terminal size (updated at import, can be refreshed during curses)
+_size = shutil.get_terminal_size(fallback=(MIN_TERMINAL_WIDTH, MIN_TERMINAL_HEIGHT))
+CURRENT_TERMINAL_WIDTH = _size.columns
+CURRENT_TERMINAL_HEIGHT = _size.lines
+
+def update_current_terminal_size(stdscr):
+    """Update CURRENT_TERMINAL_WIDTH/HEIGHT from an active curses window."""
+    global CURRENT_TERMINAL_WIDTH, CURRENT_TERMINAL_HEIGHT
+    try:
+        height, width = stdscr.getmaxyx()
+        CURRENT_TERMINAL_HEIGHT = height
+        CURRENT_TERMINAL_WIDTH = width
+    except Exception:
+        # If stdscr is invalid, keep existing values
+        pass
 # Generic UI constants
-BOX_HEIGHT = 6
-BOX_WIDTH = 14
+BOX_HEIGHT = CURRENT_TERMINAL_HEIGHT//7
+BOX_WIDTH = CURRENT_TERMINAL_WIDTH//10
 ROW_Y = 3
-BOTTOM_ROW_TEXT_Y = 10
+BOTTOM_ROW_TEXT_Y =10
 
 # X positions for git status boxes
-STATUS_X_POSITIONS = {
-    "untracked": 5,
-    "changed": 25,
-    "staged": 45,
-    "committed": 65,
+if CURRENT_TERMINAL_WIDTH>78:
+    STATUS_X_POSITIONS = {
+    "untracked": (BOX_WIDTH),
+    "changed": BOX_WIDTH+20 ,
+    "staged": BOX_WIDTH+40,
+    "committed": BOX_WIDTH+60,
+}
+else:
+    STATUS_X_POSITIONS = {
+    "untracked": (BOX_WIDTH),
+    "changed": BOX_WIDTH+10 ,
+    "staged": BOX_WIDTH+20,
+    "committed": BOX_WIDTH+30,
 }
 
 # Colors (curses color pairs)

--- a/vgit/core/ui_utils.py
+++ b/vgit/core/ui_utils.py
@@ -8,8 +8,7 @@ def check_terminal_size(stdscr):
     If not, exit gracefully with a friendly message.
     """
     rows, cols = stdscr.getmaxyx()
-
-    if rows < cfg.MIN_TERMINAL_HEIGHT or cols < cfg.MIN_TERMINAL_WIDTH:
+    if rows < 20 or cols < 60:
         curses.endwin()  # clean up curses before printing error
         print(
             f"❌ Terminal too small: {cols}x{rows} "

--- a/vgit/core/ui_utils.py
+++ b/vgit/core/ui_utils.py
@@ -8,7 +8,7 @@ def check_terminal_size(stdscr):
     If not, exit gracefully with a friendly message.
     """
     rows, cols = stdscr.getmaxyx()
-    if rows < 20 or cols < 60:
+    if rows < 20 or cols < 80:
         curses.endwin()  # clean up curses before printing error
         print(
             f"❌ Terminal too small: {cols}x{rows} "

--- a/vgit/ui.py
+++ b/vgit/ui.py
@@ -9,16 +9,16 @@ def setup_windows(stdscr):
     height, width = stdscr.getmaxyx()
     split_point = (2 * height) // 5
 
-    top_window = curses.newwin(split_point, width, 0, 0)
-    bottom_window = curses.newwin(height - split_point, width, split_point, 0)
-    return top_window, bottom_window
+    top_window = curses.newwin(height, width, 0, 0)
+    # bottom_window = curses.newwin(height - split_point, width, split_point, 0)
+    return top_window
 
 
 
 def start_curses(command_fn, full_command):
     def wrapped(stdscr):
-        top, bottom = setup_windows(stdscr)
-        runner = CommandRunner(full_command, bottom)
+        top = setup_windows(stdscr)
+        runner = CommandRunner(full_command, top)
         command_fn(top, runner)
     curses.wrapper(wrapped)
 

--- a/vgit/ui.py
+++ b/vgit/ui.py
@@ -28,7 +28,20 @@ def unsupported_command_animation(window, runner):
     controller = default_animation.start(window)
     runner.run_and_stream()
     # Wait until user presses SPACE/'q' to stop animation
-    while not controller.is_stopped():
-        time.sleep(0.1)
-    controller.stop()
+    try:
+        window.nodelay(True)
+        window.keypad(True)
+    except Exception:
+        pass
+    while True:
+        if controller.is_stopped():
+            break
+        try:
+            ch = window.getch()
+            if ch in (32, ord('q')):
+                controller.stop()
+                break
+        except Exception:
+            pass
+        time.sleep(0.05)
     print("\n".join(runner.get_output()))

--- a/vgit/ui.py
+++ b/vgit/ui.py
@@ -27,6 +27,21 @@ def start_curses(command_fn, full_command):
 def unsupported_command_animation(window, runner):
     controller = default_animation.start(window)
     runner.run_and_stream()
-    time.sleep(5)
-    controller.stop()
+    # Wait until user presses SPACE/'q' to stop animation
+    try:
+        window.nodelay(True)
+        window.keypad(True)
+    except Exception:
+        pass
+    while True:
+        if controller.is_stopped():
+            break
+        try:
+            ch = window.getch()
+            if ch in (32, ord('q')):
+                controller.stop()
+                break
+        except Exception:
+            pass
+        time.sleep(0.05)
     print("\n".join(runner.get_output()))

--- a/vgit/ui.py
+++ b/vgit/ui.py
@@ -28,20 +28,7 @@ def unsupported_command_animation(window, runner):
     controller = default_animation.start(window)
     runner.run_and_stream()
     # Wait until user presses SPACE/'q' to stop animation
-    try:
-        window.nodelay(True)
-        window.keypad(True)
-    except Exception:
-        pass
-    while True:
-        if controller.is_stopped():
-            break
-        try:
-            ch = window.getch()
-            if ch in (32, ord('q')):
-                controller.stop()
-                break
-        except Exception:
-            pass
-        time.sleep(0.05)
+    while not controller.is_stopped():
+        time.sleep(0.1)
+    controller.stop()
     print("\n".join(runner.get_output()))


### PR DESCRIPTION
Adds the required block of code to kill animations by seeking user key input.

Uses the curses's inbuilt  'window'  class to take input , a new method in the animation controller which acts as a boolean value to control the same. Also removes the auto-kill feature which killed the animation earlier after 5 seconds for complete manual control
Closes #12 